### PR TITLE
feat: Allow specific indexers in EntityIndexerRegistry

### DIFF
--- a/changelog/_unreleased/2025-04-12-entityindexerregistry-extension-indexer-only.md
+++ b/changelog/_unreleased/2025-04-12-entityindexerregistry-extension-indexer-only.md
@@ -1,0 +1,9 @@
+---
+title: Add EntityIndexerRegistry::EXTENSION_INDEXER_ONLY
+issue: N/A
+author: Niel Duysters
+author_email: niel.duysters@meteor.be
+author_github: @nielduysters
+---
+# Core
+* Added `EntityIndexerRegistry::EXTENSION_INDEXER_ONLY` to the `EntityIndexerRegistry` to allow specific indexes.

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
@@ -147,12 +147,8 @@ class EntityIndexerRegistry
             $message->setIndexer($indexer->getName());
             $message->isFullIndexing = false;
 
-            if ($context->hasExtension(self::EXTENSION_INDEXER_SKIP)) {
-                self::addSkips($message, $context);
-            }
-            if ($context->hasExtension(self::EXTENSION_INDEXER_ONLY)) {
-                self::addOnlies($message, $indexer->getOptions(), $context);
-            }
+            self::addSkips($message, $context);
+            self::addOnlies($message, $indexer->getOptions(), $context);
 
             $this->sendOrHandle($message, $useQueue);
         }

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
@@ -23,6 +23,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 class EntityIndexerRegistry
 {
     final public const EXTENSION_INDEXER_SKIP = 'indexer-skip';
+    final public const EXTENSION_INDEXER_ONLY = 'indexer-only';
 
     final public const USE_INDEXING_QUEUE = 'use-queue-indexing';
 
@@ -145,7 +146,13 @@ class EntityIndexerRegistry
 
             $message->setIndexer($indexer->getName());
             $message->isFullIndexing = false;
-            self::addSkips($message, $context);
+
+            if ($context->hasExtension(self::EXTENSION_INDEXER_SKIP)) {
+                self::addSkips($message, $context);
+            }
+            if ($context->hasExtension(self::EXTENSION_INDEXER_ONLY)) {
+                self::addOnlies($message, $indexer->getOptions(), $context);
+            }
 
             $this->sendOrHandle($message, $useQueue);
         }
@@ -164,6 +171,23 @@ class EntityIndexerRegistry
         }
 
         $message->addSkip(...$skip->get('skips'));
+    }
+
+    /**
+     * @param array<string> $options
+     */
+    public static function addOnlies(EntityIndexingMessage $message, array $options, Context $context): void
+    {
+        if (!$context->hasExtension(self::EXTENSION_INDEXER_ONLY)) {
+            return;
+        }
+        $onlies = $context->getExtension(self::EXTENSION_INDEXER_ONLY);
+        if (!$onlies instanceof ArrayEntity) {
+            return;
+        }
+        $skip = array_diff($options, $onlies->all());
+
+        $message->setSkip($skip);
     }
 
     /**

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
@@ -177,11 +177,11 @@ class EntityIndexerRegistry
         if (!$context->hasExtension(self::EXTENSION_INDEXER_ONLY)) {
             return;
         }
-        $onlies = $context->getExtension(self::EXTENSION_INDEXER_ONLY);
-        if (!$onlies instanceof ArrayEntity) {
+        $only = $context->getExtension(self::EXTENSION_INDEXER_ONLY);
+        if (!$only instanceof ArrayEntity) {
             return;
         }
-        $skip = array_diff($options, $onlies->all());
+        $skip = array_diff($options, $only->all());
 
         $message->setSkip($skip);
     }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistryTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistryTest.php
@@ -135,4 +135,25 @@ class EntityIndexerRegistryTest extends TestCase
 
         $this->registry->refresh($eventMock);
     }
+
+    public function testAddOnliesAddsCorrectSkips(): void
+    {
+        $context = Context::createDefaultContext();
+        $messageMock = $this->createMock(EntityIndexingMessage::class);
+
+        $onlyEntities = new ArrayEntity(['indexer1', 'indexer4']);
+        $context->addExtension(EntityIndexerRegistry::EXTENSION_INDEXER_ONLY, $onlyEntities);
+
+        $options = ['indexer1', 'indexer2', 'indexer3', 'indexer4'];
+
+        $messageMock->expects($this->once())
+        ->method('setSkip')
+        ->with(static::callback(function (array $skips) {
+            sort($skips);
+
+            return $skips === ['indexer2', 'indexer3'];
+        }));
+
+        EntityIndexerRegistry::addOnlies($messageMock, $options, $context);
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
When you want to exclude indexers to execute on the update of an Entity, you currently have to exclude all the indexers manually.
```php
$context->addExtension(EntityIndexerRegistry::EXTENSION_INDEXER_SKIP,
    new ArrayEntity(
        [
            // All except STOCK_UPDATER.
            ProductIndexer::INHERITANCE_UPDATER,
            ProductIndexer::VARIANT_LISTING_UPDATER,
            ProductIndexer::CHILD_COUNT_UPDATER,
            ProductIndexer::MANY_TO_MANY_ID_FIELD_UPDATER,
            ProductIndexer::CATEGORY_DENORMALIZER_UPDATER,
            ProductIndexer::CHEAPEST_PRICE_UPDATER,
            ProductIndexer::RATING_AVERAGE_UPDATER,
            ProductIndexer::STREAM_UPDATER,
            ProductIndexer::SEARCH_KEYWORD_UPDATER,
        ]
    ),
);

$this->productRepository->update([
    [
        'id' => $productId,
        'stock' => $newStock,
    ]
], $context);
```

### 2. What does this change do, exactly?
This change allows you to whitelist only the indexers you want to execute.
```php
$context->addExtension(EntityIndexerRegistry::EXTENSION_INDEXER_ONLY,
    new ArrayEntity(
        [
            // Only execute STOCK_UPDATER.
            ProductIndexer::STOCK_UPDATER
        ]
    ),
);
        
$this->productRepository->update([
    [
        'id' => $productId,
        'stock' => $newStock,
    ]
], $context);
```

### 3. Describe each step to reproduce the issue or behaviour.
I made a simple subscriber to test this code. Add an item to the cart to trigger.
<details>
<summary>View code</summary>

```php
<?php declare(strict_types=1);

namespace DemoWebshop\Subscriber;

use Psr\Log\LoggerInterface;
use Shopware\Core\Checkout\Cart\Event\AfterLineItemAddedEvent;
use Shopware\Core\Content\Product\DataAbstractionLayer\ProductIndexer;
use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
use Shopware\Core\Framework\Struct\ArrayStruct;
use Symfony\Component\EventDispatcher\EventSubscriberInterface;

class MySubscriber implements EventSubscriberInterface
{
    public function __construct(
        private readonly EntityRepository $productRepository,
        private readonly LoggerInterface $logger
    )
    {
    }

    public static function getSubscribedEvents(): array
    {
        // Return the events to listen to as array like this:  <event to listen to> => <method to execute>
        return [
            AfterLineItemAddedEvent::class => 'onAfterLineItemAdded',
        ];
    }

    public function onAfterLineItemAdded(AfterLineItemAddedEvent $event): void
    {
        $context = $event->getContext();
        $cart = $event->getCart();
        $newStock = 30;

        $context->addExtension(EntityIndexerRegistry::EXTENSION_INDEXER_SKIP,
            new ArrayStruct(
                [
                    ProductIndexer::STOCK_UPDATER
                ]
            ),
        );

        foreach ($cart->getLineItems() as $cartItem) {
            try {
                /** @var Product $product */
                $product = $this->productRepository->search(
                    (new Criteria([$cartItem->getId()]))->addAssociation('stock'),
                    $context
                )->getEntities()->first();

                $this->productRepository->update([
                    [
                        'id' => $cartItem->getId(),
                        'stock' => $newStock,
                    ]
                ], $context);
            } catch (\Exception $exception) {
                $this->logger->error($exception->getMessage());
            }
        }
    }
}
```
</details>

### 4. Please link to the relevant issues (if any).
N/A

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
